### PR TITLE
Made the paypal debug mode configurable

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,6 +34,7 @@ class Configuration
                     ->scalarNode('signature')->isRequired()->cannotBeEmpty()->end()
                     ->scalarNode('return_url')->defaultNull()->end()
                     ->scalarNode('cancel_url')->defaultNull()->end()
+                    ->booleanNode('debug')->defaultValue('%kernel.debug%')->end()
                 ->end()
             ->end()
             ->buildTree();

--- a/DependencyInjection/JMSPaymentPaypalExtension.php
+++ b/DependencyInjection/JMSPaymentPaypalExtension.php
@@ -40,5 +40,6 @@ class JMSPaymentPaypalExtension extends Extension
         $container->setParameter('payment.paypal.signature', $config['signature']);
         $container->setParameter('payment.paypal.express_checkout.return_url', $config['return_url']);
         $container->setParameter('payment.paypal.express_checkout.cancel_url', $config['cancel_url']);
+        $container->setParameter('payment.paypal.debug', $config['debug']);
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -8,7 +8,7 @@
         <parameter key="payment.plugin.paypal_express_checkout.class">Bundle\PayPalPaymentBundle\Plugin\ExpressCheckoutPlugin</parameter>
         <parameter key="payment.paypal.express_checkout.return_url"></parameter>
         <parameter key="payment.paypal.express_checkout.cancel_url"></parameter>
-        
+
         <parameter key="payment.paypal.authentication_strategy.token.class">Bundle\PayPalPaymentBundle\Authentication\TokenAuthenticationStrategy</parameter>
         <parameter key="payment.paypal.username"></parameter>
         <parameter key="payment.paypal.password"></parameter>
@@ -21,14 +21,14 @@
             <argument>%payment.paypal.password%</argument>
             <argument>%payment.paypal.signature%</argument>
         </service>
-        
+
         <service id="payment.paypal.authentication_strategy" alias="payment.paypal.authentication_strategy.token" />
-    
+
         <service id="payment.plugin.paypal_express_checkout" class="%payment.plugin.paypal_express_checkout.class%">
             <argument>%payment.paypal.express_checkout.return_url%</argument>
             <argument>%payment.paypal.express_checkout.cancel_url%</argument>
             <argument type="service" id="payment.paypal.authentication_strategy" />
-            <argument>%kernel.debug%</argument>
+            <argument>%payment.paypal.debug%</argument>
             <tag name="payment.plugin" />
         </service>
     </services>


### PR DESCRIPTION
This makes the debug mode of the paypal plugin configurable. The use case is staging servers where you run the application in the prod environment (and so a non-debug kernel) but don't want to use the real paypal site.
