### PR TITLE
Enables passing of additional parameters to express checkout

### DIFF
--- a/Plugin/ExpressCheckoutPlugin.php
+++ b/Plugin/ExpressCheckoutPlugin.php
@@ -149,7 +149,7 @@ class ExpressCheckoutPlugin extends PaypalPlugin
                 $transaction->getRequestedAmount(),
                 $this->getReturnUrl($data),
                 $this->getCancelUrl($data),
-            	$opts
+                $opts
             );
             $data->set('express_checkout_token', $response->body->get('TOKEN'));
 


### PR DESCRIPTION
The implementation does not handle encryption of the extended data. Not sure if this is needed though in the express checkout usecase. What do you think?
