### PR TITLE
added payment id to return url

### DIFF
--- a/Plugin/ExpressCheckoutPlugin.php
+++ b/Plugin/ExpressCheckoutPlugin.php
@@ -135,7 +135,8 @@ class ExpressCheckoutPlugin extends PaypalPlugin
     {
         $this->currentTransaction = $transaction;
         $data = $transaction->getExtendedData();
-
+        if($transaction->getPayment()->getId())
+            $data->set('return_url', $this->returnUrl."/".$transaction->getPayment()->getId(), false);
         $opts = $data->has('checkout_params') ? $data->get('checkout_params') : array();
         $opts['PAYMENTREQUEST_0_PAYMENTACTION'] = $paymentAction;
         $opts['PAYMENTREQUEST_0_CURRENCYCODE'] = $transaction->getPayment()->getPaymentInstruction()->getCurrency();
@@ -144,7 +145,7 @@ class ExpressCheckoutPlugin extends PaypalPlugin
         if (false === $data->has('express_checkout_token')) {
             $response = $this->requestSetExpressCheckout(
                 $transaction->getRequestedAmount(),
-                $this->getReturnUrl($data)."/".$transaction->getPayment()->getId(),
+                $this->getReturnUrl($data),
                 $this->getCancelUrl($data),
                 $opts
             );
@@ -226,7 +227,7 @@ class ExpressCheckoutPlugin extends PaypalPlugin
         );
     }
 
-    protected function getReturnUrl(ExtendedDataInterface $data)
+    protected function getReturnUrl(ExtendedDataInterface $data, $id)
     {
         if ($data->has('return_url')) {
             return $data->get('return_url');


### PR DESCRIPTION
hi,
I could not find a way to set the payment id to the return url.
I have added the paymentId to the return url in the express checkout plugin, this is for the issue #22.

thanks
