### PR TITLE
[test] refactor the way the tests are run.

### DIFF
--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+
+$composerAutoloadFile = __DIR__ . '/../vendor/.composer/autoload.php';
+if (false == file_exists($composerAutoloadFile)) {
+    die("The composer autoload file \"".$composerAutoloadFile."\" was not found.\n\nDidn't you forget to run \"php composer.phar install\"?\n");
+}
+
+$loader = include_once $composerAutoloadFile;
+
+spl_autoload_register(function($class) {
+    if (0 === strpos($class, 'JMS\\Payment\\PaypalBundle\\')) {
+        $path = __DIR__.'/../'.implode('/', array_slice(explode('\\', $class), 3)).'.php';
+        if (!stream_resolve_include_path($path)) {
+            return false;
+        }
+        require_once $path;
+        return true;
+    }
+});

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,8 @@
         }
     ],
     "require": {
+        "php": ">=5.3.2",
+        "symfony/symfony": ">=2.0,<2.2-dev",
         "jms/payment-core-bundle": "dev-master"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
-         bootstrap="./../../../../../app/bootstrap.php.cache"
->
+<phpunit bootstrap="./Tests/bootstrap.php">
     <testsuites>
-        <testsuite name="CorePaymentBundle Test Suite">
-            <directory>./Tests/</directory>
+        <testsuite name="JMSPaymentPaypalBundle">
+            <directory suffix="Test.php">./Tests</directory>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
by default it tries to use composer to autload classes. You can create `Tests/autoload.php` and define your custom   loading (for example if you want to run tests in the application env).

if someone wants to run tests he should do:
- clone your repo
- get composer and install requirements
- run phpunit.
