### PR TITLE
[plugin] set a referance code when status is pending.

### DIFF
--- a/Plugin/ExpressCheckoutPlugin.php
+++ b/Plugin/ExpressCheckoutPlugin.php
@@ -202,6 +202,8 @@ class ExpressCheckoutPlugin extends AbstractPlugin
                 break;
 
             case 'Pending':
+                $transaction->setReferenceNumber($response->body->get('PAYMENTINFO_0_TRANSACTIONID'));
+                
                 throw new PaymentPendingException('Payment is still pending: '.$response->body->get('PAYMENTINFO_0_PENDINGREASON'));
 
             default:


### PR DESCRIPTION
It is needed to fix #15

Without this change it would not possible to get transaction state by method `requestGetTransactionDetails`. 
