### PR TITLE
Added to the plugin the possibility to specify useraction in the redirect url

### DIFF
--- a/Client/Client.php
+++ b/Client/Client.php
@@ -182,14 +182,21 @@ class Client
         return new Response($parameters);
     }
 
-    public function getAuthenticateExpressCheckoutTokenUrl($token)
+    public function getAuthenticateExpressCheckoutTokenUrl($token, $useraction=null)
     {
         $host = $this->isDebug ? 'www.sandbox.paypal.com' : 'www.paypal.com';
 
+        $otherParams = "";
+        if ($useraction != null)
+        {
+          $otherParams = sprintf("&useraction=%s", urlencode($useraction));
+        }
+
         return sprintf(
-            'https://%s/cgi-bin/webscr?cmd=_express-checkout&token=%s',
+            'https://%s/cgi-bin/webscr?cmd=_express-checkout&token=%s%s',
             $host,
-            $token
+            $token,
+            $otherParams
         );
     }
 


### PR DESCRIPTION
With this modification is possible to specify the paypal useraction in ExtendedData when setting up the payment instruction.

Example, setting useraction to "commit":

```php
$data = new \JMS\Payment\CoreBundle\Entity\ExtendedData();
$data->set("cancel_url", $cancelUrl);
$data->set("return_url", $returnUrl);
$data->set("paypal_useraction", "commit");
$instruction = new PaymentInstruction($amount, $cur, 
    "paypal_express_checkout", $data);
```