### PR TITLE
Pending reason and checkout status

### DIFF
--- a/Client/Client.php
+++ b/Client/Client.php
@@ -75,6 +75,23 @@ class Client
         )));
     }
 
+    /**
+     * Implementation of re-authorization
+     *
+     * @param $authorizationId
+     * @param $amount
+     * @param array $optionalParameters
+     * @return \JMS\Payment\PaypalBundle\Client\Response
+     */
+    public function requestDoReauthorization($authorizationId, $amount, array $optionalParameters = array())
+    {
+        return $this->sendApiRequest(array_merge($optionalParameters, array(
+            'METHOD' => 'DoReauthorization',
+            'AUTHORIZATIONID' => $authorizationId,
+            'AMT' => $this->convertAmountToPaypalFormat($amount),
+        )));
+    }    
+
     public function requestDoCapture($authorizationId, $amount, $completeType, array $optionalParameters = array())
     {
         return $this->sendApiRequest(array_merge($optionalParameters, array(

--- a/Plugin/ExpressCheckoutPlugin.php
+++ b/Plugin/ExpressCheckoutPlugin.php
@@ -171,7 +171,7 @@ class ExpressCheckoutPlugin extends AbstractPlugin
 
                 throw $ex;
 
-            case 'PaymentCompleted':
+            case 'PaymentActionCompleted':
                 break;
 
             case 'PaymentActionNotInitiated':

--- a/Plugin/ExpressCheckoutPlugin.php
+++ b/Plugin/ExpressCheckoutPlugin.php
@@ -126,7 +126,7 @@ class ExpressCheckoutPlugin extends AbstractPlugin
                 throw $ex;
         }
 
-        $transaction->setReferenceNumber($authorizationId);
+        $transaction->setReferenceNumber($details->body->get('TRANSACTIONID'));
         $transaction->setProcessedAmount($details->body->get('AMT'));
         $transaction->setResponseCode(PluginInterface::RESPONSE_CODE_SUCCESS);
         $transaction->setReasonCode(PluginInterface::REASON_CODE_SUCCESS);

--- a/Plugin/ExpressCheckoutPlugin.php
+++ b/Plugin/ExpressCheckoutPlugin.php
@@ -159,7 +159,7 @@ class ExpressCheckoutPlugin extends AbstractPlugin
      */
     public function reverseDeposit(FinancialTransactionInterface $transaction, $retry)
     {
-        $transactionId = $transaction->getPayment()->getDepositTransactions()->getReferenceNumber();
+        $transactionId = $transaction->getPayment()->getDepositTransactions()->first()->getReferenceNumber();
 
         $response = $this->client->requestRefundTransaction($transactionId);
         $this->throwUnlessSuccessResponse($response, $transaction);

--- a/Plugin/ExpressCheckoutPlugin.php
+++ b/Plugin/ExpressCheckoutPlugin.php
@@ -206,7 +206,11 @@ class ExpressCheckoutPlugin extends AbstractPlugin
                 
                 $ex = new PaymentPendingException('Payment is still pending: ' . $response->body->get('PAYMENTINFO_0_PENDINGREASON'));
                 $ex->setPendingReason($response->body->get('PAYMENTINFO_0_PENDINGREASON'));
-                throw $ex;
+                if (PluginInterface::REASON_CODE_AUTHORIZATION != $response->body->get('PAYMENTINFO_0_PENDINGREASON')) {
+                    // Throw every pending exception other authorization
+                    throw $ex;
+                }
+                break;
                 
             default:
                 $ex = new FinancialException('PaymentStatus is not completed: '.$response->body->get('PAYMENTINFO_0_PAYMENTSTATUS'));

--- a/Plugin/ExpressCheckoutPlugin.php
+++ b/Plugin/ExpressCheckoutPlugin.php
@@ -146,6 +146,7 @@ class ExpressCheckoutPlugin extends AbstractPlugin
         $this->throwUnlessSuccessResponse($response, $transaction);
 
         $transaction->setResponseCode(PluginInterface::RESPONSE_CODE_SUCCESS);
+        $transaction->setReasonCode(PluginInterface::REASON_CODE_SUCCESS);
         $transaction->setReferenceNumber($response->body->get('AUTHORIZATIONID'));
         $transaction->setProcessedAmount($transaction->getRequestedAmount());
     }
@@ -171,8 +172,10 @@ class ExpressCheckoutPlugin extends AbstractPlugin
                 throw new PaymentPendingException('The refund status is delayed: ' . $response->body->get('PENDINGREASON'));
         }
 
+        $transaction->setResponseCode(PluginInterface::RESPONSE_CODE_SUCCESS);
+        $transaction->setReasonCode(PluginInterface::REASON_CODE_SUCCESS);
         $transaction->setReferenceNumber($response->body->get('REFUNDTRANSACTIONID'));
-        $transaction->setProcessedAmount($response->body->get('TOTALREFUNDEDAMT'));
+        $transaction->setProcessedAmount($response->body->get('GROSSREFUNDAMT'));
     }
 
     public function processes($paymentSystemName)

--- a/Plugin/ExpressCheckoutPlugin.php
+++ b/Plugin/ExpressCheckoutPlugin.php
@@ -105,9 +105,9 @@ class ExpressCheckoutPlugin extends AbstractPlugin
      */
     public function deposit(FinancialTransactionInterface $transaction, $retry)
     {
-        $authorizationId = $this->doCapture($transaction);
+        $transactionId = $this->doCapture($transaction);
 
-        $details = $this->client->requestGetTransactionDetails($authorizationId);
+        $details = $this->client->requestGetTransactionDetails($transactionId);
         $this->throwUnlessSuccessResponse($details, $transaction);
 
         switch ($details->body->get('PAYMENTSTATUS')) {
@@ -299,10 +299,10 @@ class ExpressCheckoutPlugin extends AbstractPlugin
     }
     
     /**
-     * Do capture - returns authorization id
+     * Do capture - returns transaction id
      *
      * @param FinancialTransactionInterface $transaction
-     * @return string $authorizationId
+     * @return string $transactionId
      */
     protected function doCapture(FinancialTransactionInterface $transaction)
     {
@@ -336,8 +336,9 @@ class ExpressCheckoutPlugin extends AbstractPlugin
                 $this->throwUnlessSuccessResponse($capture, $transaction);
             }
         }
-
-        return $authorizationId;
+        
+        // Fetch new transaction id from captured transaction
+        return $capture->body->get('TRANSACTIONID');
     }
 
     /**

--- a/Plugin/ExpressCheckoutPlugin.php
+++ b/Plugin/ExpressCheckoutPlugin.php
@@ -204,8 +204,10 @@ class ExpressCheckoutPlugin extends AbstractPlugin
             case 'Pending':
                 $transaction->setReferenceNumber($response->body->get('PAYMENTINFO_0_TRANSACTIONID'));
                 
-                throw new PaymentPendingException('Payment is still pending: '.$response->body->get('PAYMENTINFO_0_PENDINGREASON'));
-
+                $ex = new PaymentPendingException('Payment is still pending: ' . $response->body->get('PAYMENTINFO_0_PENDINGREASON'));
+                $ex->setPendingReason($response->body->get('PAYMENTINFO_0_PENDINGREASON'));
+                throw $ex;
+                
             default:
                 $ex = new FinancialException('PaymentStatus is not completed: '.$response->body->get('PAYMENTINFO_0_PAYMENTSTATUS'));
                 $ex->setFinancialTransaction($transaction);

--- a/Plugin/ExpressCheckoutPlugin.php
+++ b/Plugin/ExpressCheckoutPlugin.php
@@ -33,6 +33,11 @@ use JMS\Payment\PaypalBundle\Client\Response;
 class ExpressCheckoutPlugin extends AbstractPlugin
 {
     /**
+     * The payment is pending because it has been authorized but not settled. You must capture the funds first.
+     */
+    const REASON_CODE_PAYPAL_AUTHORIZATION = 'authorization';
+    
+    /**
      * @var string
      */
     protected $returnUrl;
@@ -206,7 +211,7 @@ class ExpressCheckoutPlugin extends AbstractPlugin
                 
                 $ex = new PaymentPendingException('Payment is still pending: ' . $response->body->get('PAYMENTINFO_0_PENDINGREASON'));
                 $ex->setPendingReason($response->body->get('PAYMENTINFO_0_PENDINGREASON'));
-                if (PluginInterface::REASON_CODE_AUTHORIZATION != $response->body->get('PAYMENTINFO_0_PENDINGREASON')) {
+                if (self::REASON_CODE_PAYPAL_AUTHORIZATION != $response->body->get('PAYMENTINFO_0_PENDINGREASON')) {
                     // Throw every pending exception other authorization
                     throw $ex;
                 }

--- a/Plugin/ExpressCheckoutPlugin.php
+++ b/Plugin/ExpressCheckoutPlugin.php
@@ -211,8 +211,6 @@ class ExpressCheckoutPlugin extends AbstractPlugin
                 break;
 
             case 'PaymentActionNotInitiated':
-                break;
-
             default:
                 $actionRequest = new ActionRequiredException('User has not yet authorized the transaction.');
                 $actionRequest->setFinancialTransaction($transaction);

--- a/Plugin/ExpressCheckoutPlugin.php
+++ b/Plugin/ExpressCheckoutPlugin.php
@@ -211,6 +211,11 @@ class ExpressCheckoutPlugin extends AbstractPlugin
                 break;
 
             case 'PaymentActionNotInitiated':
+                if ('verified' == $details->body->get('PAYERSTATUS')) {
+                    // If payment is verified - going on
+                    break;
+                }
+                
             default:
                 $actionRequest = new ActionRequiredException('User has not yet authorized the transaction.');
                 $actionRequest->setFinancialTransaction($transaction);

--- a/Plugin/ExpressCheckoutPlugin.php
+++ b/Plugin/ExpressCheckoutPlugin.php
@@ -301,10 +301,10 @@ class ExpressCheckoutPlugin extends AbstractPlugin
     /**
      * Do capture - returns authorization id
      *
-     * @param $transaction
+     * @param FinancialTransactionInterface $transaction
      * @return string $authorizationId
      */
-    protected function doCapture($transaction)
+    protected function doCapture(FinancialTransactionInterface $transaction)
     {
         $authorizationId = $transaction->getPayment()->getApproveTransaction()->getReferenceNumber();
 

--- a/Tests/Plugin/ExpressCheckoutPluginTest.php
+++ b/Tests/Plugin/ExpressCheckoutPluginTest.php
@@ -305,7 +305,7 @@ class ExpressCheckoutPluginTest extends \PHPUnit_Framework_TestCase
 
         $requestGetExpressCheckoutDetailsResponse = new Response(array(
             'ACK' => 'Success',
-            'CHECKOUTSTATUS' => 'PaymentCompleted'
+            'CHECKOUTSTATUS' => 'PaymentActionCompleted'
         ));
 
         $requestDoExpressCheckoutPaymentResponse = new Response(array(

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "~2.0",
-        "jms/payment-core-bundle": "~1.0"
+        "sveriger/payment-core-bundle": "~1.0"
     },
     "require-dev": {
         "symfony/browser-kit": "*"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "~2.0",
-        "sveriger/payment-core-bundle": "~1.0"
+        "jms/payment-core-bundle": "~1.0"
     },
     "require-dev": {
         "symfony/browser-kit": "*"


### PR DESCRIPTION
Hi,

I add the pending reason to the payment pending exception, for better handling the reason in controller.

Additional I fixed the wrong Checkout-Status. The API-Doc says:

It is one of the following values:

    PaymentActionNotInitiated
    PaymentActionFailed
    PaymentActionInProgress
    PaymentActionCompleted

In https://developer.paypal.com/webapps/developer/docs/classic/api/merchant/GetExpressCheckoutDetails_API_Operation_NVP/

I tried and can confirm.

Would be very kind of you to merge this and also create new tagged version.

Thanks

Sven