### PR TITLE
fix cancel payment prozess

### DIFF
--- a/Plugin/ExpressCheckoutPlugin.php
+++ b/Plugin/ExpressCheckoutPlugin.php
@@ -171,11 +171,14 @@ class ExpressCheckoutPlugin extends AbstractPlugin
 
                 throw $ex;
 
-            case 'PaymentCompleted':
+            case 'PaymentActionCompleted':
                 break;
 
             case 'PaymentActionNotInitiated':
-                break;
+                if ('verified' == $details->body->get('PAYERSTATUS')) {
+                    // If payment is verified - going on
+                    break;
+                }
 
             default:
                 $actionRequest = new ActionRequiredException('User has not yet authorized the transaction.');

--- a/Tests/Plugin/ExpressCheckoutPluginTest.php
+++ b/Tests/Plugin/ExpressCheckoutPluginTest.php
@@ -305,7 +305,8 @@ class ExpressCheckoutPluginTest extends \PHPUnit_Framework_TestCase
 
         $requestGetExpressCheckoutDetailsResponse = new Response(array(
             'ACK' => 'Success',
-            'CHECKOUTSTATUS' => 'PaymentCompleted'
+            'CHECKOUTSTATUS' => 'PaymentActionCompleted',
+            'PAYERSTATUS' => 'verified',
         ));
 
         $requestDoExpressCheckoutPaymentResponse = new Response(array(
@@ -345,6 +346,98 @@ class ExpressCheckoutPluginTest extends \PHPUnit_Framework_TestCase
         }
         catch (PaymentPendingException $ex) {
             $this->assertEquals($expectedTransactionId, $transaction->getReferenceNumber());
+        }
+    }
+
+    public function testPaymentActionNotInitiatedUnverifiedPayer()
+    {
+        $expectedToken = 'the_express_checkout_token';
+
+        $requestGetExpressCheckoutDetailsResponse = new Response(array(
+            'ACK' => 'Success',
+            'CHECKOUTSTATUS' => 'PaymentActionNotInitiated',
+            'PAYERSTATUS' => 'unverified',
+        ));
+
+        $clientMock = $this->createClientMock($mockedMethods = array(
+            'requestSetExpressCheckout',
+            'requestGetExpressCheckoutDetails',
+            'requestDoExpressCheckoutPayment'
+        ));
+        $clientMock
+            ->expects($this->never())
+            ->method('requestSetExpressCheckout')
+        ;
+        $clientMock
+            ->expects($this->once())
+            ->method('requestGetExpressCheckoutDetails')
+            ->will($this->returnValue($requestGetExpressCheckoutDetailsResponse))
+        ;
+        $clientMock
+            ->expects($this->never())
+            ->method('requestDoExpressCheckoutPayment')
+        ;
+
+        $plugin = new ExpressCheckoutPlugin('return_url', 'cancel_url', $clientMock);
+
+        $transaction = $this->createTransaction($amount = 100, 'EUR');
+        $transaction->getExtendedData()->set('express_checkout_token', $expectedToken);
+
+        try {
+            $plugin->approve($transaction, false);
+            $this->fail('Plugin was expected to throw an exception.');
+        }
+        catch (ActionRequiredException $ex) {
+        }
+    }
+
+    public function testPaymentActionNotInitiatedVerifiedPayer()
+    {
+        $expectedTransactionId = 'the_transaction_id';
+        $expectedToken = 'the_express_checkout_token';
+
+        $requestGetExpressCheckoutDetailsResponse = new Response(array(
+            'ACK' => 'Success',
+            'CHECKOUTSTATUS' => 'PaymentActionNotInitiated',
+            'PAYERSTATUS' => 'verified',
+        ));
+        $requestDoExpressCheckoutPaymentResponse = new Response(array(
+            'ACK' => 'Success',
+            'PAYMENTINFO_0_PAYMENTSTATUS' => 'Pending',
+            'PAYMENTINFO_0_TRANSACTIONID' => $expectedTransactionId,
+            'PAYMENTINFO_n_PENDINGREASON' => 'none',
+        ));
+
+        $clientMock = $this->createClientMock($mockedMethods = array(
+            'requestSetExpressCheckout',
+            'requestGetExpressCheckoutDetails',
+            'requestDoExpressCheckoutPayment'
+        ));
+        $clientMock
+            ->expects($this->never())
+            ->method('requestSetExpressCheckout')
+        ;
+        $clientMock
+            ->expects($this->once())
+            ->method('requestGetExpressCheckoutDetails')
+            ->will($this->returnValue($requestGetExpressCheckoutDetailsResponse))
+        ;
+        $clientMock
+            ->expects($this->once())
+            ->method('requestDoExpressCheckoutPayment')
+            ->will($this->returnValue($requestDoExpressCheckoutPaymentResponse))
+        ;
+
+        $plugin = new ExpressCheckoutPlugin('return_url', 'cancel_url', $clientMock);
+
+        $transaction = $this->createTransaction($amount = 100, 'EUR');
+        $transaction->getExtendedData()->set('express_checkout_token', $expectedToken);
+
+        try {
+            $plugin->approve($transaction, false);
+            $this->fail('Plugin was expected to throw an exception.');
+        }
+        catch (PaymentPendingException $ex) {
         }
     }
 


### PR DESCRIPTION
Hi John,

would you merge the following fix to ensure, user can continue payment after interrupt or canceling paypal process.

Thanks,
Sven