### PR TITLE
Throw every pending exception other than authorization

### DIFF
--- a/Plugin/ExpressCheckoutPlugin.php
+++ b/Plugin/ExpressCheckoutPlugin.php
@@ -215,6 +215,7 @@ class ExpressCheckoutPlugin extends AbstractPlugin
                     // Throw every pending exception other authorization
                     throw $ex;
                 }
+                break;
 
             default:
                 $ex = new FinancialException('PaymentStatus is not completed: '.$response->body->get('PAYMENTINFO_0_PAYMENTSTATUS'));

--- a/Tests/Plugin/ExpressCheckoutPluginTest.php
+++ b/Tests/Plugin/ExpressCheckoutPluginTest.php
@@ -4,6 +4,7 @@ namespace JMS\Payment\PaypalBundle\Tests\Plugin;
 
 use JMS\Payment\CoreBundle\Plugin\Exception\ActionRequiredException;
 use JMS\Payment\CoreBundle\Plugin\Exception\PaymentPendingException;
+use JMS\Payment\CoreBundle\Plugin\Exception\FinancialException;
 use JMS\Payment\CoreBundle\Entity\FinancialTransaction;
 use JMS\Payment\CoreBundle\Entity\Payment;
 use JMS\Payment\CoreBundle\Entity\ExtendedData;
@@ -345,6 +346,55 @@ class ExpressCheckoutPluginTest extends \PHPUnit_Framework_TestCase
         }
         catch (PaymentPendingException $ex) {
             $this->assertEquals($expectedTransactionId, $transaction->getReferenceNumber());
+        }
+    }
+
+    public function testPaymentActionNotInitiatedVerifiedPayerButAuthorization()
+    {
+        $expectedTransactionId = 'the_transaction_id';
+        $expectedToken = 'the_express_checkout_token';
+
+        $requestGetExpressCheckoutDetailsResponse = new Response(array(
+            'ACK' => 'Success',
+            'CHECKOUTSTATUS' => 'PaymentActionNotInitiated',
+            'PAYERSTATUS' => 'verified',
+        ));
+        $requestDoExpressCheckoutPaymentResponse = new Response(array(
+            'ACK' => 'Success',
+            'PAYMENTINFO_0_PAYMENTSTATUS' => 'Pending',
+            'PAYMENTINFO_0_TRANSACTIONID' => $expectedTransactionId,
+            'PAYMENTINFO_0_PENDINGREASON' => 'authorization',
+        ));
+
+        $clientMock = $this->createClientMock($mockedMethods = array(
+            'requestSetExpressCheckout',
+            'requestGetExpressCheckoutDetails',
+            'requestDoExpressCheckoutPayment'
+        ));
+        $clientMock
+            ->expects($this->never())
+            ->method('requestSetExpressCheckout')
+        ;
+        $clientMock
+            ->expects($this->once())
+            ->method('requestGetExpressCheckoutDetails')
+            ->will($this->returnValue($requestGetExpressCheckoutDetailsResponse))
+        ;
+        $clientMock
+            ->expects($this->once())
+            ->method('requestDoExpressCheckoutPayment')
+            ->will($this->returnValue($requestDoExpressCheckoutPaymentResponse))
+        ;
+
+        $plugin = new ExpressCheckoutPlugin('return_url', 'cancel_url', $clientMock);
+
+        $transaction = $this->createTransaction($amount = 100, 'EUR');
+        $transaction->getExtendedData()->set('express_checkout_token', $expectedToken);
+
+        try {
+            $plugin->approve($transaction, false);
+            $this->fail('Plugin was expected to throw an exception.');
+        } catch(FinancialException $ex) {
         }
     }
 


### PR DESCRIPTION
Hi John,

this fix is to be able separate real pending payments and authorized one's. This is important for partial payments.

Greetings,
Sven