### PR TITLE
Support for Symfony 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,24 @@
 language: php
-php:
-  - 5.4
-  - 5.3
 
-before_script:
-  - composer install --dev
+branches:
+  only:
+    - master
+matrix:
+  include:
+    - php: 5.3
+      env: SYMFONY_VERSION=2.8.*
+    - php: 7.0
+      env: SYMFONY_VERSION=2.3.*
+    - php: 7.0
+      env: SYMFONY_VERSION=2.8.*
+    - php: 7.0
+      env: SYMFONY_VERSION=3.1.*
+
+before_install:
+  # Disable xdebug for improved performance
+  - phpenv config-rm xdebug.ini
+  # Prevent Travis throwing an out of memory error on PHP 5.3
+  - if [[ $(phpenv version-name) == 5.3 ]]; then echo "memory_limit=-1" >> ~/.phpenv/versions/5.3/etc/conf.d/travis.ini; fi
+
+before_script: composer install --prefer-dist
+script: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,17 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "~2.0",
+        "symfony/browser-kit": "~2.0|~3.0",
+        "symfony/config": "~2.0|~3.0",
+        "symfony/dependency-injection": "~2.0|~3.0",
+        "symfony/form": "~2.0|~3.0",
+        "symfony/http-foundation": "~2.0|~3.0",
+        "symfony/http-kernel": "~2.0|~3.0",
         "jms/payment-core-bundle": "~1.0"
     },
     "require-dev": {
-        "symfony/browser-kit": "*"
+        "phpunit/phpunit": "~4.8|~5.4",
+        "symfony/phpunit-bridge": "~2.7"
     },
     "autoload": {
         "psr-0": { "JMS\\Payment\\PaypalBundle": "" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,4 +13,8 @@
         <server name="API_PASSWORD" value="1283340321" />
         <server name="API_SIGNATURE" value="A93vj6VJ.ZIRNjbI6GFgi4N2Km.5ATLs-EinlyWk2htEGX0xc3L8YIBo" />
     </php>
+
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+    </php>
 </phpunit>


### PR DESCRIPTION
This PR introduces support for Symfony 3. In addition, instead of requiring the `framework-bundle`, only dependencies that are actually needed are required.