### PR TITLE
Allow setting a useraction parameter in the redirect URL

### DIFF
--- a/Client/Client.php
+++ b/Client/Client.php
@@ -183,15 +183,18 @@ class Client
         return new Response($parameters);
     }
 
-    public function getAuthenticateExpressCheckoutTokenUrl($token)
+    public function getAuthenticateExpressCheckoutTokenUrl($token, array $params = array())
     {
         $host = $this->isDebug ? 'www.sandbox.paypal.com' : 'www.paypal.com';
+        $params = array_merge(array('token' => $token), $params);
 
-        return sprintf(
-            'https://%s/cgi-bin/webscr?cmd=_express-checkout&token=%s',
-            $host,
-            $token
-        );
+        $url = sprintf('https://%s/cgi-bin/webscr?cmd=_express-checkout', $host);
+
+        foreach ($params as $key => $value) {
+            $url .= sprintf('&%s=%s', $key, $value);
+        }
+
+        return $url;
     }
 
     public function convertAmountToPaypalFormat($amount)

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -35,6 +35,7 @@ class Configuration
                     ->scalarNode('return_url')->defaultNull()->end()
                     ->scalarNode('cancel_url')->defaultNull()->end()
                     ->scalarNode('notify_url')->defaultNull()->end()
+                    ->scalarNode('useraction')->defaultNull()->end()
                     ->booleanNode('debug')->defaultValue('%kernel.debug%')->end()
                 ->end()
             ->end()

--- a/DependencyInjection/JMSPaymentPaypalExtension.php
+++ b/DependencyInjection/JMSPaymentPaypalExtension.php
@@ -41,6 +41,7 @@ class JMSPaymentPaypalExtension extends Extension
         $container->setParameter('payment.paypal.express_checkout.return_url', $config['return_url']);
         $container->setParameter('payment.paypal.express_checkout.cancel_url', $config['cancel_url']);
         $container->setParameter('payment.paypal.express_checkout.notify_url', $config['notify_url']);
+        $container->setParameter('payment.paypal.express_checkout.useraction', $config['useraction']);
         $container->setParameter('payment.paypal.debug', $config['debug']);
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -9,12 +9,13 @@
         <parameter key="payment.paypal.express_checkout.return_url"></parameter>
         <parameter key="payment.paypal.express_checkout.cancel_url"></parameter>
         <parameter key="payment.paypal.express_checkout.notify_url"></parameter>
+        <parameter key="payment.paypal.express_checkout.useraction"></parameter>
 
         <parameter key="payment.paypal.authentication_strategy.token.class">JMS\Payment\PaypalBundle\Client\Authentication\TokenAuthenticationStrategy</parameter>
         <parameter key="payment.paypal.username"></parameter>
         <parameter key="payment.paypal.password"></parameter>
         <parameter key="payment.paypal.signature"></parameter>
-        
+
         <parameter key="payment.form.paypal_express_checkout_type.class">JMS\Payment\PaypalBundle\Form\ExpressCheckoutType</parameter>
 
         <parameter key="payment.paypal.client.class">JMS\Payment\PaypalBundle\Client\Client</parameter>
@@ -34,6 +35,7 @@
             <argument>%payment.paypal.express_checkout.cancel_url%</argument>
             <argument type="service" id="payment.paypal.client" />
             <argument>%payment.paypal.express_checkout.notify_url%</argument>
+            <argument>%payment.paypal.express_checkout.useraction%</argument>
             <tag name="payment.plugin" />
         </service>
 
@@ -41,7 +43,7 @@
             <argument type="service" id="payment.paypal.authentication_strategy" />
             <argument>%payment.paypal.debug%</argument>
         </service>
-        
+
         <service id="payment.form.paypal_express_checkout_type" class="%payment.form.paypal_express_checkout_type.class%">
             <tag name="payment.method_form_type" />
             <tag name="form.type" alias="paypal_express_checkout" />

--- a/Tests/Client/ClientTest.php
+++ b/Tests/Client/ClientTest.php
@@ -6,40 +6,46 @@ use JMS\Payment\PaypalBundle\Client\Client;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
-    public static function provideExpectedAuthenticateExpressCheckoutTokenUrlsDependsOnDebugFlag()
+    public function testShouldAllowGetAuthenticateExpressCheckoutTokenUrlInProdMode()
     {
-        return array(
-            array(true, 'foobar', 'https://www.sandbox.paypal.com'),
-            array(false, 'barfoo', 'https://www.paypal.com'),
-        );
+        $expectedUrl = 'https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=foobar';
+        $token = 'foobar';
+
+        $client = $this->getClient($debug = false);
+
+        $this->assertEquals($expectedUrl, $client->getAuthenticateExpressCheckoutTokenUrl($token));
     }
 
     public function testShouldAllowGetAuthenticateExpressCheckoutTokenUrlInDebugMode()
     {
-        $expectedUrl = 'https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=foobar';
-
+        $expectedUrl = 'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=foobar';
         $token = 'foobar';
 
-        $client = new Client($this->createAuthenticationStrategyMock(), $debug = false);
+        $client = $this->getClient($debug = true);
 
         $this->assertEquals($expectedUrl, $client->getAuthenticateExpressCheckoutTokenUrl($token));
     }
 
-    public function testShouldAllowGetAuthenticateExpressCheckoutTokenUrlInProdMode()
+    public function testGetAuthenticateExpressCheckoutTokenUrlParams()
     {
-        $expectedUrl = 'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=foobar';
-
+        $expectedUrl = 'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=foobar&param1=foo&param2=bar';
         $token = 'foobar';
+        $params = array('param1' => 'foo', 'param2' => 'bar');
 
-        $client = new Client($this->createAuthenticationStrategyMock(), $debug = true);
+        $client = $this->getClient($debug = true);
 
-        $this->assertEquals($expectedUrl, $client->getAuthenticateExpressCheckoutTokenUrl($token));
+        $this->assertEquals($expectedUrl, $client->getAuthenticateExpressCheckoutTokenUrl($token, $params));
+    }
+
+    private function getClient($debug)
+    {
+        return new Client($this->createAuthenticationStrategyMock(), $debug);
     }
 
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|\JMS\Payment\PaypalBundle\Client\Authentication\AuthenticationStrategyInterface
      */
-    public function createAuthenticationStrategyMock()
+    private function createAuthenticationStrategyMock()
     {
         return $this->getMockBuilder('JMS\Payment\PaypalBundle\Client\Authentication\AuthenticationStrategyInterface')->getMock();
     }

--- a/Tests/Functional/Client/ClientTest.php
+++ b/Tests/Functional/Client/ClientTest.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace JMS\Payment\PaypalBundle\Tests\Functional\Paypal;
+namespace JMS\Payment\PaypalBundle\Tests\Functional\Client;
 
-use JMS\Payment\PaypalBundle\Client\Authentication\TokenAuthenticationStrategy;
-use JMS\Payment\PaypalBundle\Client\Client;
+use JMS\Payment\PaypalBundle\Tests\Functional\FunctionalTest;
 
 /*
  * Copyright 2010 Johannes M. Schmitt <schmittjoh@gmail.com>
@@ -21,26 +20,16 @@ use JMS\Payment\PaypalBundle\Client\Client;
  * limitations under the License.
  */
 
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends FunctionalTest
 {
     /**
      * @var \JMS\Payment\PaypalBundle\Client\Client
      */
-    protected $client;
+    private $client;
 
     protected function setUp()
     {
-        if (empty($_SERVER['API_USERNAME']) || empty($_SERVER['API_PASSWORD']) || empty($_SERVER['API_SIGNATURE'])) {
-            $this->markTestSkipped('In order to run these tests you have to configure: API_USERNAME, API_PASSWORD, API_SIGNATURE parameters in phpunit.xml file');
-        }
-
-        $authenticationStrategy = new TokenAuthenticationStrategy(
-            $_SERVER['API_USERNAME'],
-            $_SERVER['API_PASSWORD'],
-            $_SERVER['API_SIGNATURE']
-        );
-
-        $this->client = new Client($authenticationStrategy, $debug = true);
+        $this->client = $this->getClient();
     }
 
     public function testRequestSetExpressCheckout()

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace JMS\Payment\PaypalBundle\Tests\Functional;
+
+use JMS\Payment\PaypalBundle\Client\Authentication\TokenAuthenticationStrategy;
+use JMS\Payment\PaypalBundle\Client\Client;
+
+abstract class FunctionalTest extends \PHPUnit_Framework_TestCase
+{
+    protected function getClient()
+    {
+        if (empty($_SERVER['API_USERNAME']) || empty($_SERVER['API_PASSWORD']) || empty($_SERVER['API_SIGNATURE'])) {
+            $this->markTestSkipped('In order to run these tests you have to configure: API_USERNAME, API_PASSWORD, API_SIGNATURE parameters in phpunit.xml file');
+        }
+
+        $authenticationStrategy = new TokenAuthenticationStrategy(
+            $_SERVER['API_USERNAME'],
+            $_SERVER['API_PASSWORD'],
+            $_SERVER['API_SIGNATURE']
+        );
+
+        return new Client($authenticationStrategy, $debug = true);
+    }
+}

--- a/Tests/Functional/Plugin/ExpressCheckoutPluginTest.php
+++ b/Tests/Functional/Plugin/ExpressCheckoutPluginTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace JMS\Payment\PaypalBundle\Tests\Functional\Plugin;
+
+use JMS\Payment\CoreBundle\Entity\ExtendedData;
+use JMS\Payment\CoreBundle\Entity\FinancialTransaction;
+use JMS\Payment\CoreBundle\Entity\Payment;
+use JMS\Payment\CoreBundle\Entity\PaymentInstruction;
+use JMS\Payment\CoreBundle\Plugin\Exception\ActionRequiredException;
+use JMS\Payment\PaypalBundle\Plugin\ExpressCheckoutPlugin;
+use JMS\Payment\PaypalBundle\Tests\Functional\FunctionalTest;
+
+class ExpressCheckoutPluginTest extends FunctionalTest
+{
+    public function testApproveNoUserActionByDefault()
+    {
+        $plugin = new ExpressCheckoutPlugin(
+            'http://example.com',
+            'http://example.com',
+            $this->getClient()
+        );
+
+        $transaction = $this->getTransaction();
+
+        try {
+            $plugin->approve($transaction, $retry = false);
+        } catch (ActionRequiredException $ex) {
+            $action = $ex->getAction();
+            $this->assertInstanceOf('JMS\Payment\CoreBundle\Plugin\Exception\Action\VisitUrl', $action);
+            $this->assertNotContains('useraction', $action->getUrl());
+        }
+    }
+
+    public function testApproveWithUserAction()
+    {
+        $plugin = new ExpressCheckoutPlugin(
+            'http://example.com',
+            'http://example.com',
+            $this->getClient(),
+            null,
+            'commit'
+        );
+
+        $transaction = $this->getTransaction();
+
+        try {
+            $plugin->approve($transaction, $retry = false);
+        } catch (ActionRequiredException $ex) {
+            $action = $ex->getAction();
+            $this->assertInstanceOf('JMS\Payment\CoreBundle\Plugin\Exception\Action\VisitUrl', $action);
+            $this->assertContains('useraction=commit', $action->getUrl());
+        }
+    }
+
+    public function testApproveWithUserActionInExtendedData()
+    {
+        $plugin = new ExpressCheckoutPlugin(
+            'http://example.com',
+            'http://example.com',
+            $this->getClient()
+        );
+
+        $transaction = $this->getTransaction();
+        $transaction->getExtendedData()->set('useraction', 'commit');
+
+        try {
+            $plugin->approve($transaction, $retry = false);
+        } catch (ActionRequiredException $ex) {
+            $action = $ex->getAction();
+            $this->assertInstanceOf('JMS\Payment\CoreBundle\Plugin\Exception\Action\VisitUrl', $action);
+            $this->assertContains('useraction=commit', $action->getUrl());
+        }
+    }
+
+    private function getTransaction()
+    {
+        $amount = 123.45;
+        $instruction = new PaymentInstruction($amount, 'EUR', 'foo', new ExtendedData());
+        $payment = new Payment($instruction, $amount);
+
+        $transaction = new FinancialTransaction();
+        $transaction->setPayment($payment);
+        $transaction->setRequestedAmount($amount);
+
+        return $transaction;
+    }
+}


### PR DESCRIPTION
Fixes #60 
Replaces #46 
Documented in #79 

Allow setting a `useraction` parameter in the URL, [as per the ExpressCheckout documentation](https://developer.paypal.com/docs/classic/express-checkout/integration-guide/ECCustomizing/#id0864860D0YK).

This can either be done globally, through the bundle configuration:

```yaml
jms_payment_paypal:
    useraction: commit
```

Or per transaction:

```php
$data->set('useraction', 'commit');
```
